### PR TITLE
ABLESTACK 방화벽(49152/tcp) 추가

### DIFF
--- a/kickstart/scripts/Ablestack.xml
+++ b/kickstart/scripts/Ablestack.xml
@@ -13,5 +13,6 @@
   <port port="9929" protocol="udp"/>
   <port port="2049" protocol="tcp"/>
   <port port="123" protocol="udp"/>
+  <port port="49152" protocol="tcp"/>
   <port port="49152" protocol="udp"/>
 </service>


### PR DESCRIPTION
ablestack-cockpit-plugin 이슈 #246
Bug 개요
mold에서 호스트 마이그레이션을 할 경우 필요한 방화벽 포트(49152/tcp)에 대한 ablestack 방화벽 정책에 추가 필요

- [x]  ABLESTACK 방화벽(49152/tcp) 추가