### PR TITLE
root 사용자의 password 만료 스크립트 추가

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -108,6 +108,9 @@ chmod -R 755 chmod -R 755 /usr/share/cockpit/ablestack/
 sed -i "1s/.*/title ABLESTACK Allo(v1.0.0)/g" /boot/loader/entries/*el8*
 sed -i "1s/.*/title ABLESTACK Allo(v1.0.0) Rescue/g" /boot/loader/entries/*rescue*
 
+#root user password expired
+passwd -e root
+
 %end
 
 %anaconda


### PR DESCRIPTION
cockpit 최초 접속 시 root 사용자의 비밀번호를 재설정 하기 위한 비밀번호 만료 스크립트 추가
