### PR TITLE
ablestack-cerato_VARS.fd 권한 업데이트

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -99,6 +99,8 @@ pip3 install $dst_dir/whls/*.whl
 
 # ablestack-template(scvm,ccvm) UEFI fd 파일 복사
 /usr/bin/cp -f $dst_dir/settings/ablestack-cerato_VARS.fd /var/lib/libvirt/qemu/nvram/ablestack-cerato_VARS.fd
+chown qemu:qemu /var/lib/libvirt/qemu/nvram/ablestack-cerato_VARS.fd
+chmod 777 /var/lib/libvirt/qemu/nvram/ablestack-cerato_VARS.fd
 
 
 # login fail count

--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -110,7 +110,7 @@ authselect enable-feature with-faillock
 authselect apply-changes
 
 # ABLESTACK Branding
-sed -i 's/CentOS Stream 8/ABLESTACK Cube (VERSION)/g' /etc/os-release
+sed -i 's/CentOS Stream 8/ABLESTACK Cube VERSION/g' /etc/os-release
 
 /usr/bin/sh /root/updateMirror.sh
 rm -rf /root/updateMirror.sh
@@ -143,8 +143,8 @@ echo password | passwd hacluster --stdin
 chmod -R 755 /usr/share/cockpit/ablestack/
 
 # bootloader entry branding
-sed -i "1s/.*/title ABLESTACK Cerato(v3.0.0)/g" /boot/loader/entries/*el8*
-sed -i "1s/.*/title ABLESTACK Cerato(v3.0.0) Rescue/g" /boot/loader/entries/*rescue*
+sed -i "1s/.*/title ABLESTACK VERSION/g" /boot/loader/entries/*el8*
+sed -i "1s/.*/title ABLESTACK VERSION Rescue/g" /boot/loader/entries/*rescue*
 
 # exporter 서비스 자동 실행
 systemctl enable --now libvirt-exporter

--- a/kickstart/scripts/branding.css
+++ b/kickstart/scripts/branding.css
@@ -19,10 +19,10 @@ body.login-pf {
 
 /* ABLESTACK 브렌딩 추가 시작 */
 #brand:before {
-    content: "ABLESTACK Cube (Cerato v3.0.0)";
+    content: "ABLESTACK Cube VERSION";
 }
 
 #index-brand:before {
-    content: "ABLESTACK Cube (Cerato v3.0.0)";
+    content: "ABLESTACK Cube VERSION";
 }
 /* ABLESTACK 브렌딩 추가 끝 */


### PR DESCRIPTION
ablestack-cerato_VARS.fd 사용자 및 권한 업데이트
/var/lib/libvirt/qemu/nvram/ablestack-cerato_VARS.fd 파일 권한 변경

원인 : root 사용자에 read 권한밖에 없어 virsh start를 하지 못함
해결 : qemu, wx 권한 부여 (-rwxrwxrwx.  qemu qemu  ablestack-cerato_VARS.fd)



