### PR TITLE
UEFI nvram 파일 설정으로 ccvm이 실행되지 않는 문제 해결

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -125,6 +125,13 @@ qemu-img create -f qcow2 -b /var/lib/libvirt/images/ablestack-template.qcow2 -F 
 # lspci 명령어 심볼릭 링크 생성
 ln -s /usr/sbin/lspci /usr/bin/
 
+# qemu.con 파일 수정(remember owner)
+### Whether libvirt should remember and restore the original
+### ownership over files it is relabeling. Defaults to 1, set
+### to 0 to disable the feature.
+### remember_owner = 1
+sed -i 's/\#remember_owner = 1/remember_owner = 0/' /etc/libvirt/qemu.conf
+
 #설치 완료 파일 삭제 
 #rm -rf $dst_dir/scripts/
 #rm -rf $dst_dir/rpms/


### PR DESCRIPTION
바이오스 모드를 UEFI로 변경하면서 생긴 이슈로 SELINUX등의 설정이 기존 fd 파일에 저장되어 있어 해당 가상머신이 정상적으로 실행되지 않는 문제가 발견되었습니다.
/etc/libvirt/qemu.conf 파일의 remember owner 기본 값을 변경하면 문제가 해결됩니다.

qemu.conf의 remember owner 설명(주석)
Whether libvirt should remember and restore the original
ownership over files it is relabeling. Defaults to 1, set to 0 to disable the feature.