### PR TITLE
cockpit favicon bug fix

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -111,6 +111,7 @@ authselect apply-changes
 
 # ABLESTACK Branding
 sed -i 's/CentOS Stream 8/ABLESTACK Cube VERSION/g' /etc/os-release
+ln -s -f /usr/share/pixmaps/ablestack/favicon.png /etc/favicon.png
 
 /usr/bin/sh /root/updateMirror.sh
 rm -rf /root/updateMirror.sh


### PR DESCRIPTION
ABLESTACK CUBE web console favicon bug fix

ablestack-cockpit repo의 빌드 과정에서 favicon 브랜딩이 정상적으로 되지 않는 버그가 발견되었습니다.
버전이 변경되면서 favicon을 표시하는 디렉토리가 변경된 것으로 보여 기존 브랜딩 위치의 파일로 링크를 걸어 정상적으로 표시 하도록 변경하였습니다.

