### PR TITLE
방화벽 포트 허용 기본 설정

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -144,6 +144,10 @@ systemctl enable --now cockpit.socket
 systemctl enable --now pcsd
 systemctl enable --now lldpd.service
 
+# 방화벽 포트 허용
+firewall-cmd --add-service=Ablestack --permanent
+firewall-cmd --reload
+
 # pcs user password 설정
 echo password | passwd hacluster --stdin
 


### PR DESCRIPTION
에이블스택 설치 과정 중 에이블스택 방화벽 허용 포트 설정 방법을 변경하였습니다.

기존 : OS 설치 후 Cube(cockpit)의 네트워크 설정에서 사용자가 방화벽을 선택하여 허용하는 방식
변경 : kickstart 스크립트를 이용하여 사용자를 거치지 않고 OS 설치 단계에서 허용하는 방식

firewall --enabled을 이용하여 스크립트 자체에서 방화벽을 허용할 수 있지만, 향후 관리를 위해서 기존 xml(에이블스택에서 사용하는 방화벽 허용 포트 리스트를 정의하는 xml 파일)을 그대로 유지하고 서비스를 enabled 하는 방식으로 하는 것이 좋을 것 같다고 판단하여 반영하였습니다.