### PR TITLE
Mirror update 스크립트 주석 처리

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -113,8 +113,9 @@ authselect apply-changes
 sed -i 's/CentOS Stream 8/ABLESTACK Cube VERSION/g' /etc/os-release
 ln -s -f /usr/share/pixmaps/ablestack/favicon.png /etc/favicon.png
 
-/usr/bin/sh /root/updateMirror.sh
-rm -rf /root/updateMirror.sh
+# rpm Mirror update
+#/usr/bin/sh /root/updateMirror.sh
+#rm -rf /root/updateMirror.sh
 
 # 기본 repo 비활성화
 sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo


### PR DESCRIPTION
PR 내용
 RPM Mirror 업데이트 주석 처리

CentOS 8 stream으로 기본 OS를 변경함에 따라 CentOS 8 Linux에서 사용하기 위해 업데이트 하였던 RPM Mirror 업데이트 스크립트를 주석 처리 했습니다.