### PR TITLE
ABLESTACK Cerato 변경

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -41,7 +41,7 @@ firstboot --disable
 clearpart --all --initlabel
 
 # System timezone
-timezone Asia/Seoul --isUtc --ntpservers=2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org
+timezone Etc/UTC --isUtc --ntpservers=2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org
 
 # Root password는 사용자가 직접 설정하도록 함
 # Root password

--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -17,10 +17,10 @@ kexec-tools
 %end
 
 # Keyboard layouts
-keyboard --vckeymap=kr --xlayouts='kr'
+keyboard --xlayouts='us'
 
 # System language
-lang ko_KR.UTF-8
+lang en_US.UTF-8
 
 # ABLESTACK 환경 설정
 bootloader --append="intel_iommu=on"


### PR DESCRIPTION
ABLESTACK Cerato에서 변경된 내용을 수정하였습니다.
1. 스크립트 변경
- 키보드 레이아웃 및 기본 언어 설정 변경 (한국어 -> 영어)
- 시간 설정 변경 (timezone : KST -> UTC)
