### PR TITLE
ROOT 비밀번호 기본 설정 추가

### DIFF
--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -43,7 +43,6 @@ clearpart --all --initlabel
 # System timezone
 timezone Etc/UTC --isUtc --ntpservers=2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org
 
-# Root password는 사용자가 직접 설정하도록 함
 # Root password
 rootpw password
 

--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -44,7 +44,7 @@ clearpart --all --initlabel
 timezone Etc/UTC --isUtc --ntpservers=2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org,2.centos.pool.ntp.org
 
 # Root password
-rootpw password
+rootpw --plaintext password
 
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 

--- a/kickstart/ks/ablestack-ks.cfg
+++ b/kickstart/ks/ablestack-ks.cfg
@@ -45,7 +45,7 @@ timezone Etc/UTC --isUtc --ntpservers=2.centos.pool.ntp.org,2.centos.pool.ntp.or
 
 # Root password는 사용자가 직접 설정하도록 함
 # Root password
-# rootpw --iscrypted $6$wSpfTZDa3NEM0K.l$qoX3D39EfQkJNHKoxclWkhZs2MbdFizF8M8wOXNxDr3Ng17kllK0AYZM6Cg5sq7T3I.w1VuvsaC8x.xs7gQC4/
+rootpw password
 
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 


### PR DESCRIPTION
최초 설계 및 개발 당시 root password를 사용자가 입력 받도록 하였는데 설치 마지막 단계에서 root password 만료하고 최초 로그인 시  비밀번호를 입력 받아 root password를 재설정하게 하는 방식으로 변경되면서 root password를 설치 단계에서 입력 받는 것이 번거로우며 필요하지 않아 삭제하였습니다.

기존 : root password를 설치 단계에서 입력받고 설치가 끝나면 설정한 비밀번호와 다른 비밀번호로 변경해야 함
- 설치 단계에서 번거로울 수 있음
- 설치 후 다른 패스워드로 변경해야 하므로 불편할 수 있음

변경 : 설치 단계에서 default password를 설정하여 설치 후 최초 로그인 시 변경할 수 있도록 변경 